### PR TITLE
Fix incorrect counter on changing more than one character at once

### DIFF
--- a/TextFieldCounter.swift
+++ b/TextFieldCounter.swift
@@ -140,16 +140,17 @@ open class TextFieldCounter: UITextField, UITextFieldDelegate {
         prepareToAnimateCounterLabel(count: count)
     }
     
-    private func getTextFieldCharactersCount(textField: UITextField, string: String) -> Int {
+    private func getTextFieldCharactersCount(textField: UITextField, string: String, changeCharactersIn range: NSRange) -> Int {
         
         var textFieldCharactersCount = 0
         
         if let textFieldText = textField.text {
             
-            textFieldCharactersCount = textFieldText.characters.count + string.characters.count
             
-            if string.isEmpty {
-                textFieldCharactersCount = textFieldCharactersCount - 1
+            if !string.isEmpty {
+                textFieldCharactersCount = textFieldText.characters.count + string.characters.count - range.length
+            } else {
+                textFieldCharactersCount = textFieldText.characters.count - range.length
             }
         }
         
@@ -220,7 +221,7 @@ open class TextFieldCounter: UITextField, UITextFieldDelegate {
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         
         var shouldChange = false
-        let textFieldCharactersCount = getTextFieldCharactersCount(textField: textField, string: string)
+        let textFieldCharactersCount = getTextFieldCharactersCount(textField: textField, string: string, changeCharactersIn: range)
         
         if string.isEmpty {
             shouldChange = true

--- a/TextFieldCounter/TextFieldCounterTests/TextFieldCounterTests.swift
+++ b/TextFieldCounter/TextFieldCounterTests/TextFieldCounterTests.swift
@@ -22,7 +22,7 @@ class TextFieldCounterTests: XCTestCase {
     func testTextGreaterThanTheLimit() {
         let textField = TextFieldCounter(frame: CGRect.zero, limit: 10, animate: true, ascending: true, counterColor: .black, limitColor: .red)
         let text = "hello hello hello"
-        let range = NSMakeRange(0, text.characters.count)
+        let range = NSMakeRange(0, 0)
         
         XCTAssertFalse(textField.textField(textField, shouldChangeCharactersIn: range, replacementString: text))
     }
@@ -30,9 +30,8 @@ class TextFieldCounterTests: XCTestCase {
     func testTextLessThanTheLimit() {
         let textField = TextFieldCounter(frame: CGRect.zero, limit: 10, animate: true, ascending: true, counterColor: .black, limitColor: .red)
         let text = "hello"
-        let range = NSMakeRange(0, text.characters.count)
+        let range = NSMakeRange(0, 0)
         
         XCTAssertTrue(textField.textField(textField, shouldChangeCharactersIn: range, replacementString: text))
     }
-    
 }


### PR DESCRIPTION
On selection and then deleting / pasting / cutting text wrong text length was displayed. The reason is not checking `shouldChangeCharactersIn` parameter.

I also had to set correct range in tests. Parameter `shouldChangeCharactersIn` should
be (0, 0), because it is initial text input.