### PR TITLE
Localizing counterLabel

### DIFF
--- a/TextFieldCounter.swift
+++ b/TextFieldCounter.swift
@@ -112,8 +112,12 @@ open class TextFieldCounter: UITextField, UITextFieldDelegate {
         return label
     }
     
+    private func localizedString(of number: Int) -> String {
+        return String.localizedStringWithFormat("%i", number)
+    }
+    
     private func getCounterLabelWidth() -> Int {
-        let biggestText = "\(maxLength)"
+        let biggestText = localizedString(of: maxLength)
         
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = .left
@@ -131,9 +135,9 @@ open class TextFieldCounter: UITextField, UITextFieldDelegate {
     private func updateCounterLabel(count: Int) {
         if count <= maxLength {
             if (ascending) {
-                counterLabel.text = "\(count)"
+                counterLabel.text = localizedString(of: count)
             } else {
-                counterLabel.text = "\(maxLength - count)"
+                counterLabel.text = localizedString(of: maxLength - count)
             }
         }
         

--- a/TextFieldCounter.swift
+++ b/TextFieldCounter.swift
@@ -104,7 +104,7 @@ open class TextFieldCounter: UITextField, UITextFieldDelegate {
         if let currentFont : UIFont = font {
             label.font = currentFont
             label.textColor = counterColor
-            label.textAlignment = .left
+            label.textAlignment = label.userInterfaceLayoutDirection == .rightToLeft ? .right : .left
             label.lineBreakMode = .byWordWrapping
             label.numberOfLines = 1
         }
@@ -256,6 +256,14 @@ extension UIView {
         UIView.animate(withDuration: duration, delay: 0, options: .curveEaseInOut, animations: {
             self.transform = CGAffineTransform.identity
         }, completion: nil)
+    }
+    
+    var userInterfaceLayoutDirection: UIUserInterfaceLayoutDirection {
+        if #available(iOS 9.0, *) {
+            return UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute)
+        } else {
+            return UIApplication.shared.userInterfaceLayoutDirection
+        }
     }
     
 }


### PR DESCRIPTION
This includes:
- Localizing the number on counterLabel.
- Changing the counterLabel text alignment to work well on both left to right and right to left layouts.

Before on right to left layouts:
![screen shot 2017-08-27 at 7 31 37 am](https://user-images.githubusercontent.com/21133646/29747232-2f811016-8afb-11e7-8aa6-a21b8b61aeda.png)
**Notice** how the number is very close to the edge of the text field, that because of the text alignment.

After:
![screen shot 2017-08-27 at 7 42 40 am](https://user-images.githubusercontent.com/21133646/29747233-5527b11c-8afb-11e7-8291-ae491205ac68.png)
